### PR TITLE
Update CrewQ.cs

### DIFF
--- a/Source/CrewQ.cs
+++ b/Source/CrewQ.cs
@@ -93,11 +93,11 @@ namespace CrewQ
 
                 if (CrewQData.Instance.settingVacationHardlock)
                 {
-                    _AvailableCrew = HighLogic.CurrentGame.CrewRoster.Crew.Where(x => x.OnVacation() == false);
+                    _AvailableCrew = HighLogic.CurrentGame.CrewRoster.Crew.Where(x => x.OnVacation() == false && x.rosterStatus == ProtoCrewMember.RosterStatus.Available);
                 }
                 else
                 {
-                    _AvailableCrew = HighLogic.CurrentGame.CrewRoster.Crew;
+                    _AvailableCrew = HighLogic.CurrentGame.CrewRoster.Crew.Where (x => x.rosterStatus == ProtoCrewMember.RosterStatus.Available);
                 }
 
                 try


### PR DESCRIPTION
Fixes issue where unavailable Kerbals can appear in the AvailableCrew list. Ex: Jebediah Kerman might be walking around the Mun but you can assign him to a new ship on Kerbin. Now you have two Jebs. The crew complex will say there's only one Kerbal on assignment on the Assigned tab but if you click the Assigned tab you will then see two Jebediah Kerman listings with their respective vehicles.

The fix is to add another Where clause delimiting the list with x.rosterStatus == ProtoCrewMember.RosterStatus.Available
